### PR TITLE
Fix OAB linking from HTTP domain to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,7 +117,7 @@
                 Prior to her counselling practice she worked with adults and youth in violence and abuse prevention programming with a focus on child abuse, bullying and healthy relationships. She presented to audiences dealing with these issues through out the province.<br/><br/>
                 Group presentations and phone consults are available upon request.<br/><br/>
                 Cindie is welcoming to all faith backgrounds and gender identities, and believes in creating a culturally safe space for clients.<br/><br/>
-                For more information please contact me or set up a phone consult. To book an appointment, please go to <a href="https://oab.owlpractice.ca/#/neudorfcindie/1/calendar" class="btn btn-default btn-xl">Cindie's Calendar.</a> Evening appointments on request.</p>
+                For more information please contact me or set up a phone consult. To book an appointment, please go to <a href="https://oab.owlpractice.ca/#/neudorfcindie/1/calendar" target="_blank" class="btn btn-default btn-xl">Cindie's Calendar.</a> Evening appointments on request.</p>
                 <a href="#contact" class="btn btn-default btn-xl">Contact me!</a>
                 <p></p>
             </div>
@@ -139,7 +139,7 @@
             <div class="col-lg-8 col-lg-offset-2 text-center">
                 <p class="text-faded"> Pain, heartache and suffering is not something anyone anticipates experiencing. When it comes out of no-where it may seem too unbearable to handle. Individuals may suppress what they are feeling, behave in ways they never thought they would, and/or experience secondary symptoms that mask what is truly going on.<br/><br/>
                 Whether it is the initial pain you are experiencing and/or years of wear and tear, please know that there is help available to you. With experience and extensive training in Marriage and Family Therapy, I am passionate about helping clients from all walks of life. I would be honoured to help you make sense of your experiences. <br/><br/>
-                Chelsey is currently doing her internship, and is available at reduced rates starting at $50 per session. To book an appointment with Chelsey , please go to <a href="https://oab.owlpractice.ca/#/neudorfcindie/2/calendar" class="btn btn-default btn-xl">Chelsey's Calendar.</a></p>
+                Chelsey is currently doing her internship, and is available at reduced rates starting at $50 per session. To book an appointment with Chelsey , please go to <a href="https://oab.owlpractice.ca/#/neudorfcindie/2/calendar" target="_blank" class="btn btn-default btn-xl">Chelsey's Calendar.</a></p>
                 <a href="#contact" class="btn btn-default btn-xl">Contact me!</a>
             </div>
         </div>


### PR DESCRIPTION
Adding a target="_blank" will open the OAB link in a new tab and should solve the issue of switching from an HTTP domain to a HTTPS domain. Using https://neudorf.github.io/cindieneudorfcounselling/ and then clicking the OAB button works normally on latest versions of Chrome, Safari, and Firefox.